### PR TITLE
Fix to use logger for stdout for debugging

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -218,7 +218,7 @@ def kinesis_put(log_records: list):
     failed = list()
     for record in log_records:
         failed_records = []
-        print(record)
+        logger.debug(record)
 
         data_blob = json.dumps(record).encode('utf-8')
 


### PR DESCRIPTION
Fix debugging output from stdout print() to logger.debug().