### PR TITLE
Use PutRecords to write in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ terraform.tfvars
 ### Python
 venv/
 .pyc
+bin/
 
 ### Others
 build/

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -252,10 +252,11 @@ def kinesis_put(log_records: list):
             xray_recorder.end_subsegment()
 
             if response['FailedRecordCount'] == 0:
+                xray_recorder.end_subsegment()
                 break
             else:
                 retry_count += 1
-                subsegment.put_annotation("records", len(records))
+                subsegment.put_annotation("failed_records", response['FailedRecordCount'])
                 for index, record in enumerate(response['Records']):
                     if 'ErrorCode' in record:
                         if record['ErrorCode'] == 'ProvisionedThroughputExceededException':
@@ -269,6 +270,7 @@ def kinesis_put(log_records: list):
                 if len(retry_list) > 0:
                     logger.info(f"Waiting 1 second for capacity")
                     time.sleep(1)
+            xray_recorder.end_subsegment()
 
     xray_recorder.end_subsegment()
     return failed_list

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -230,12 +230,10 @@ def kinesis_put(log_records: list):
         records = []
         for record in batch:
             data_blob = json.dumps(record).encode('utf-8')
-            partition_key: str = ''.join(random.choices(RANDOM_ALPHANUMERICAL, k=20))
+            partition_key: str = ''.join(random.choices(RANDOM_ALPHANUMERICAL, k=20)) # max 256 chars
             records.append({
-                {
-                    'Data':            data_blob,
-                    'PartitionKey':    partition_key,
-                },
+                'Data':            data_blob,
+                'PartitionKey':    partition_key,
             })
 
         logger.debug(records)


### PR DESCRIPTION
After load testing this function, I found out that sending records with put_record calls (one record per call) are too slow for production. 

We can use [put_records](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis.html#Kinesis.Client.put_records) instead, to write in batches of up to 500 records.

Because put_records doesn't throw exceptions on capacity, I had to rewrite retry logic.