### PR TITLE
Add access registered consumer policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,12 +102,22 @@ module "iam" {
             "Effect": "Allow",
             "Action": [
                 "kinesis:DescribeStream",
+                "kinesis:DescribeStreamSummary",
                 "kinesis:PutRecord",
                 "kinesis:PutRecords",
                 "kinesis:ListStreams"
             ],
             "Resource": [
                 "${data.aws_kinesis_stream.target.arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:SubscribeToShard",
+            ],
+            "Resource": [
+                "${data.aws_kinesis_stream.target.arn}/consumer/*:*"
             ]
         },
         {


### PR DESCRIPTION
Add access registered consumer policy to forwarder lambda role, because an error occurred when trying to set event source mapping.

occurred ERROR
```
Cannot access event source {consumer arn}. Please ensure the role can perform the DescribeStreamSummary, ListShards, GetShardIterator and GetRecords actions on your stream and SubscribeToShard on your consumer in IAM. (Service: AWSLambda; Status Code: 400; Error Code: InvalidParameterValueException; Request ID:)
```

consumer arn format
`arn:aws:kinesis:{{region}}:{{accounted}}:stream/{stream name}/consumer/{consumer name}:{create timestamp}`
