### PR TITLE
Ignore boto3 updates in pyup for dev dependencies

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,6 +1,6 @@
+boto3 # pyup: ignore
+
 aws_kinesis_agg==1.1.2
 aws-xray-sdk==2.4.3
-boto3==1.12.12
 python-dateutil==2.8.1
 amazon_kinesis_utils==0.1.6
-


### PR DESCRIPTION
Lambda runtime has latest, and for deploy packages we do not vendor boto anyway.